### PR TITLE
Disable compiling pip

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 #set -x
 
-WASI_SDK_PATH=/opt/wasi-sdk
+WASI_SDK_PATH="${WASI_SDK_PATH:-/opt/wasi-sdk}"
 PYTHON_DIR=cpython
 WASIX_DIR=wasix
 PROJECT_DIR=$(pwd)
@@ -94,6 +94,7 @@ cp ${WASI_SDK_PATH}/share/misc/config.sub . && \
    autoconf -f && \
    ./configure --host=wasm32-wasi --build=x86_64-pc-linux-gnu \
                --with-build-python=${PYTHON_DIR}/inst/${PYTHON_VER}/bin/python${PYTHON_VER} \
+               --with-ensurepip=no \
                --disable-ipv6 --enable-big-digits=30 --with-suffix=.wasm \
                --with-freeze-module=./build/Programs/_freeze_module \
 	       --prefix=${INSTALL_PREFIX}/wasi-python && \


### PR DESCRIPTION
Compiling with ensurepip errors when building on macos

```
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/Users/areese/p/src/github.com/singlestore-labs/python-wasi/cpython/Lib/ensurepip/__init__.py", line 4, in <module>
    import subprocess
    ^^^^^^^^^^^^^^^^^
  File "/Users/areese/p/src/github.com/singlestore-labs/python-wasi/cpython/Lib/subprocess.py", line 99, in <module>
    import _posixsubprocess
    ^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_posixsubprocess'
make: *** [install] Error 1
```